### PR TITLE
Update API.md and example for v5.4.1

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -2,7 +2,6 @@
 
 
 - [initSdk](#initSdk)
-- [trackAppLaunch](#trackAppLaunch)
 - [onInstallConversionData](#onInstallConversionData) 
 - [onAppOpenAttribution](#onAppOpenAttribution) 
 - [trackEvent](#trackEvent)
@@ -79,68 +78,6 @@ try {
 ```
 
 ---
-##### <a id="trackAppLaunch"> **`trackAppLaunch()`**
-
-(iOS Only)
-
-Necessary for tracking sessions and deep link callbacks in iOS on background-to-foreground transitions.<br/>
-This API Should be used with the relevant [AppState](https://facebook.github.io/react-native/docs/appstate.html) logic.
-
-*Example:*
-
-```javascript
-state = {
-  appState: AppState.currentState,
-};
-
-componentDidMount();
-{
-  AppState.addEventListener('change', this._handleAppStateChange);
-}
-
-componentWillUnmount();
-{
-  AppState.removeEventListener('change', this._handleAppStateChange);
-}
-
-_handleAppStateChange = (nextAppState) => {
-  if (this.state.appState.match(/inactive|background/) && nextAppState === 'active') {
-    if (Platform.OS === 'ios') {
-      appsFlyer.trackAppLaunch();
-    }
-  }
-
-  this.setState({appState: nextAppState});
-};
-```
-
-
-Or with Hooks:
-
-```javascript
-const [appState, setAppState] = useState(AppState.currentState);
-
-useEffect(() => {
-  function handleAppStateChange(nextAppState) {
-    if (appState.match(/inactive|background/) && nextAppState === 'active') {
-      if (Platform.OS === 'ios') {
-        appsFlyer.trackAppLaunch();
-      }
-    }
-
-    setAppState(nextAppState);
-  }
-
-  AppState.addEventListener('change', handleAppStateChange);
-
-  return () => {
-    AppState.removeEventListener('change', handleAppStateChange);
-  };
-});
-```
-
----
-
 ##### <a id="onInstallConversionData"> **`onInstallConversionData(callback) : function:unregister`**
 
 Accessing AppsFlyer Attribution / Conversion Data from the SDK (Deferred Deeplinking).<br/>

--- a/examples/demo/App.js
+++ b/examples/demo/App.js
@@ -4,7 +4,6 @@ import {
   View,
   Text,
   Button,
-  AppState
 } from 'react-native';
 import appsFlyer from 'react-native-appsflyer';
 
@@ -59,17 +58,7 @@ class App extends React.Component {
 
   }
 
-  state = {
-    appState: AppState.currentState
-  }
-
-  componentDidMount() {
-    AppState.addEventListener('change', this._handleAppStateChange);
-  }
-
   componentWillUnmount() {
-    AppState.removeEventListener('change', this._handleAppStateChange);
-    
     // Optionaly remove listeners for deep link data if you no longer need them
     if (onInstallConversionDataCanceller) {
       onInstallConversionDataCanceller();
@@ -83,32 +72,22 @@ class App extends React.Component {
     }
   }
 
-    _handleAppStateChange = (nextAppState) => {
-    if (this.state.appState.match(/inactive|background/) && nextAppState === 'active') {
-      if (Platform.OS === 'ios') {
-        appsFlyer.trackAppLaunch();
+  TrackEventPressed() {
+    const eventName = "af_test_event";
+    const eventValues = {
+        "af_event_param0" : "biz",
+        "af_event_param1" : "buz",
+        "af_event_param2" : "bizbuz"
+    };
+    appsFlyer.trackEvent(eventName, eventValues,
+      (result) => {
+        console.log(result);
+      },
+      (error) => {
+        console.error(error);
       }
-    }
-    this.setState({appState: nextAppState});
-  };
-
-
-     TrackEventPressed() {
-      const eventName = "af_test_event";
-      const eventValues = {
-          "af_event_param0" : "biz",
-          "af_event_param1" : "buz",
-          "af_event_param2" : "bizbuz"
-      };
-      appsFlyer.trackEvent(eventName, eventValues,
-        (result) => {
-          console.log(result);
-        },
-        (error) => {
-          console.error(error);
-        }
-      )
-    }
+    )
+  }
 
   render() {
     return (


### PR DESCRIPTION
From version v5.4.1, I noticed that there is no need to call `trackAppLaunch` from `_handleAppStateChange`
I'm sure that API documentation and example should be updated.