### PR TITLE
Update README link to iOS 14.5 ATT docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Run `pod install`
 ## <a id="init-sdk"> 🚀 Initializing the SDK
 
 Initialize the SDK to enable AppsFlyer to detect installations, sessions (app opens) and updates.<br>
-NOTE! for iOS 14.5, we use `timeToWaitForATTUserAuthorization` parameter. please read more [Here](https://support.appsflyer.com/hc/en-us/articles/207032066-iOS-SDK-V6-X-integration-guide-for-developers#additional-apis-configuring-app-tracking-transparency-att-support)
+NOTE! for iOS 14.5, we use `timeToWaitForATTUserAuthorization` parameter. Please read more [here](https://support.appsflyer.com/hc/en-us/articles/207032066-iOS-SDK-V6-X-integration-guide-for-developers#integration-33-configuring-app-tracking-transparency-att-support)
+
 ```javascript
 import React, {Component} from 'react';
 import {Platform, StyleSheet, Text, View} from 'react-native';


### PR DESCRIPTION
I think this is the correct, equivalent link — the old one goes to the "additional APIs" tab, which doesn't discuss ATT anymore.