### PR TITLE
Update API.md - set CUID before `initSDK`

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -230,7 +230,7 @@ appsFlyer.logEvent(
 
 ##### <a id="setCustomerUserId"> **`setCustomerUserId(userId, callback)`**
 
-Setting your own Custom ID enables you to cross-reference your own unique ID with AppsFlyer’s user ID and the other devices’ IDs. This ID is available in AppsFlyer CSV reports along with postbacks APIs for cross-referencing with you internal IDs.
+Setting your own Custom ID enables you to cross-reference your own unique ID with AppsFlyer’s user ID and the other devices’ IDs. This ID is available in AppsFlyer CSV reports along with postbacks APIs for cross-referencing with you internal IDs. NOTE: This must be set before `initSdk` is called.
 
 
 | parameter | type     | description      |


### PR DESCRIPTION
Add a note for proper processing of CUID in newer versions of the SDK. Our implementation broke (CUID wasn't showing up in Appsflyer data export) after upgrading from `^5.4.1` to `^6.1.41` and it was only fixed after looking at the sample app and matching the sequence there of `setCustomerUserId` -> `initSdk`. Hopefully this added note will help other users experiencing similar troubles.