### PR TITLE
Remove jcenter() as it is deprecated

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,6 @@ def safeExtGet(prop, fallback) {
 
 buildscript {
     repositories {
-        jcenter()
         maven {
             url 'https://maven.google.com/'
             name 'Google'


### PR DESCRIPTION
Jcenter has been deprecated and should no longer be used.  https://blog.gradle.org/jcenter-shutdown


I'm getting an error when using appsflyer in a react-native app when running `gradlew assembleRelease`

```   
* What went wrong: 
A problem occurred configuring project ':react-native-appsflyer'. 
> Could not resolve all artifacts for configuration ':react-native-appsflyer:classpath'. 
 > Could not resolve com.android.tools.build:gradle-api:4.0.0. 
 Required by: 
 project :react-native-appsflyer > com.android.tools.build:gradle:4.0.0 
 project :react-native-appsflyer > com.android.tools.build:gradle:4.0.0 > com.android.tools.lint:lint-gradle-api:27.0.0 
 > Could not resolve com.android.tools.build:gradle-api:4.0.0. 
 > Could not get resource 'https://jcenter.bintray.com/com/android/tools/build/gradle-api/4.0.0/gradle-api-4.0.0.pom'. 
 > Could not GET 'https://jcenter.bintray.com/com/android/tools/build/gradle-api/4.0.0/gradle-api-4.0.0.pom'. Received status code 502 from server: Bad Gateway
 ```
 
 

`com.android.tools.build:gradle:4.0.0` is already part of maven.google.com, so everything should just work when removing this `jcenter()` line:

https://maven.google.com/web/index.html#com.android.tools.build:gradle:4.0.0

