### PR TITLE
Prevent warnings when RNAppsFlyerStrictMode is false

### DIFF
--- a/react-native-appsflyer.podspec
+++ b/react-native-appsflyer.podspec
@@ -21,8 +21,10 @@ Pod::Spec.new do |s|
     s.dependency 'AppsFlyerFramework/Strict', '6.6.1'
     s.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) AFSDK_NO_IDFA=1' }
   else
-    Pod::UI.puts "#{s.name}: Using default AppsFlyerFramework.You may require App Tracking Transparency. Not allowed for Kids apps."
-    Pod::UI.puts "#{s.name}: You may set variable `$RNAppsFlyerStrictMode=true` in Podfile to use strict mode for kids apps."
+    if !defined?($RNAppsFlyerStrictMode)
+      Pod::UI.puts "#{s.name}: Using default AppsFlyerFramework.You may require App Tracking Transparency. Not allowed for Kids apps."
+      Pod::UI.puts "#{s.name}: You may set variable `$RNAppsFlyerStrictMode=true` in Podfile to use strict mode for kids apps."
+    end
     s.dependency 'AppsFlyerFramework', '6.6.1'
   end
 end


### PR DESCRIPTION
When RNAppsFlyerStrictMode is set to false in Podfile, there should be no warning printed.

### Description

There is a warning that is printed anytime this variable is undefined or not true. That is helpful when the variable is undefined, but there's no reason to print the warning if a dev has explicitly set it to false.
