### PR TITLE
Fixed undefined of shouldUseStrictMode expo bared

### DIFF
--- a/expo/withAppsFlyer.js
+++ b/expo/withAppsFlyer.js
@@ -1,5 +1,5 @@
 const withAppsFlyerIos = require('./withAppsFlyerIos');
-module.exports = function withAppsFlyer(config, { shouldUseStrictMode = false }) {
-	config = withAppsFlyerIos(config, shouldUseStrictMode);
+module.exports = function withAppsFlyer(config, strictModeConfig) {
+	config = withAppsFlyerIos(config, strictModeConfig?.shouldUseStrictMode === true);
 	return config;
 };


### PR DESCRIPTION
When install the library to Expo Bared project, I got the error `Cannot read properties of undefined (reading 'shouldUseStrictMode').` which the property `shouldUseStrictMode` is getting from `app.json` but it's not found on bared project.

Note: The project I'm working with is using Expo SDK 42