### PR TITLE
Bump iOS 6.8.0 -> 6.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ### <a id="plugin-build-for"> This plugin is built for
 
 - Android AppsFlyer SDK **v6.8.0**
-- iOS AppsFlyer SDK **v6.8.0**
+- iOS AppsFlyer SDK **v6.8.1**
 
 ## <a id="breaking-changes"> 	❗❗ Breaking changes when updating to v6.x.x❗❗
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-appsflyer",
-  "version": "6.8.0",
+  "version": "6.8.1",
   "description": "React Native Appsflyer plugin",
   "main": "index.js",
   "types": "index.d.ts",

--- a/react-native-appsflyer.podspec
+++ b/react-native-appsflyer.podspec
@@ -18,13 +18,13 @@ Pod::Spec.new do |s|
   # AppsFlyerFramework
   if defined?($RNAppsFlyerStrictMode) && ($RNAppsFlyerStrictMode == true)
     Pod::UI.puts "#{s.name}: Using AppsFlyerFramework/Strict mode"
-    s.dependency 'AppsFlyerFramework/Strict', '6.8.0'
+    s.dependency 'AppsFlyerFramework/Strict', '6.8.1'
     s.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) AFSDK_NO_IDFA=1' }
   else
     if !defined?($RNAppsFlyerStrictMode)
       Pod::UI.puts "#{s.name}: Using default AppsFlyerFramework. You may require App Tracking Transparency. Not allowed for Kids apps."
       Pod::UI.puts "#{s.name}: You may set variable `$RNAppsFlyerStrictMode=true` in Podfile to use strict mode for kids apps."
     end
-    s.dependency 'AppsFlyerFramework', '6.8.0'
+    s.dependency 'AppsFlyerFramework', '6.8.1'
   end
 end


### PR DESCRIPTION
6.8.0 is deprecated: https://support.appsflyer.com/hc/en-us/articles/115001224823-AppsFlyer-iOS-SDK-release-notes