### PR TITLE
Fix for incompatible config for React Native Versions >= 0.69.X

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -3,7 +3,6 @@ const path = require('path');
 module.exports = {
   dependency: {
     platforms: {
-      ios: { podspecPath: path.join(__dirname, 'react-native-appsflyer.podspec') },
       android: {
         packageImportPath: 'import com.appsflyer.reactnative.RNAppsFlyerPackage;',
         packageInstance: 'new RNAppsFlyerPackage()',


### PR DESCRIPTION
As the title states, this fixes warnings introduced for all react native versions greater than or equal to 0.69

This issue was brought up in both https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/421 and https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/395 but both were mysteriously closed.