### PR TITLE
Update GenerateInviteLinkParams interface type definition.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -102,9 +102,15 @@ declare module "react-native-appsflyer" {
         channel: string;
         campaign?: string;
         customerID?: string;
-        userParams?: object;
-
-        [key: string]: any;
+        userParams?: {
+            deep_link_value?: string;
+            [key: string]: any;
+        };
+        referrerName?: string;
+        referrerImageUrl?: string;
+        deeplinkPath?: string;
+        baseDeeplink?: string;
+        brandDomain?: string;
     }
 
     const appsFlyer: {


### PR DESCRIPTION
There are a few issues with `GenerateInviteLinkParams` interface which affect SDK functionality.

According to `GenerateInviteLinkParams` interface, any parameter can be put into the generated url, except some of them which are explicitly set, at least `[key: string]: any;` signature says so.

However, in native implementation of this method, `generateInviteLink` , are accepted a strict number of parameters.

Since type definitions are provided, to enhance developer experience it should be explicitly set what parameters are accepted and affect the proper SDK work.

Documentation has to be updated as well probably.