### PR TITLE
Explicitly check for is_first_launch instead of using JSON.parse

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -919,7 +919,8 @@ The code implementation for the conversion listener must be made prior to the in
 ```javascript
 const onInstallConversionDataCanceller = appsFlyer.onInstallConversionData(
   (res) => {
-    if (JSON.parse(res.data.is_first_launch) == true) {
+    // Note that `is_first_launch` will be "true" (string) on Android and true (boolean) on iOS.
+    if (res.data.is_first_launch === "true" || res.data.is_first_launch === true) {
       if (res.data.af_status === 'Non-organic') {
         var media_source = res.data.media_source;
         var campaign = res.data.campaign;
@@ -949,8 +950,6 @@ appsFlyer.initSdk(/*...*/);
   "type": "onInstallConversionDataLoaded"
 }
 ```
-
-> **Note** is_first_launch will be "true" (string) on Android and true (boolean) on iOS. To solve this issue wrap is_first_launch with JSON.parse(res.data.is_first_launch) as in the example above.
 
 `appsFlyer.onInstallConversionData` returns a function the will allow us to call `NativeAppEventEmitter.remove()`.<br/>
 


### PR DESCRIPTION
I think it's better to have an explicit, TypeScript-friendly `is_first_launch` check instead of using the obscure `JSON.parse` variant. Besides that, loose equality operator (double equals) is generally not recommended and it's even disabled with linter rules.

It would be even better to not have the string `"true"` in `is_first_launch` type but I don't know why it was done this way.