### PR TITLE
Update platforms to include tvos

### DIFF
--- a/react-native-appsflyer.podspec
+++ b/react-native-appsflyer.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author           = pkg["author"]
   s.source           = { :git => pkg["repository"]["url"] }
   s.source_files     = 'ios/**/*.{h,m}'
-  s.platform         = :ios, "9.0"
+  s.platforms        = { :ios => "9.0", :tvos => "12.0" }
   s.static_framework = true
   s.dependency 'React'
 


### PR DESCRIPTION
I was getting errors regarding AppsFlyer in a tv project I'm currently working, I notice tvOS is not supported so I update the platforms in order to include it. 