### PR TITLE
fix(build.gradle): updated to latest af-android-sdk for hostname fix

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,5 +54,5 @@ repositories {
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
     implementation "com.android.installreferrer:installreferrer:${safeExtGet('installReferrerVersion', '2.1')}"
-    api "com.appsflyer:af-android-sdk:${safeExtGet('appsflyerVersion', '6.9.4')}"
+    api "com.appsflyer:af-android-sdk:${safeExtGet('appsflyerVersion', '6.10.1')}"
 }


### PR DESCRIPTION
We are facing many crashes in the production with error `Unable to resolve host "inapps.appsflyer.com": No address associated with hostname`, hence have update af-android-sdk to latest which contains Appsflyer domain changes

https://support.appsflyer.com/hc/en-us/articles/115001256006-AppsFlyer-Android-SDK-release-notes