### PR TITLE
Add support for NSAdvertisingAttributionReportEndpoint through Expo config

### DIFF
--- a/expo/withAppsFlyerIos.js
+++ b/expo/withAppsFlyerIos.js
@@ -67,8 +67,18 @@ function withPodfile(config, shouldUseStrictMode) {
 	]);
 }
 
-module.exports = function withAppsFlyerIos(config, shouldUseStrictMode) {
+function withPlistAdvertisingAttribution(config, url) {
+	  return withInfoPlist(config, async config => {
+    		const infoPlist = config.modResults;
+    		infoPlist.NSAdvertisingAttributionReportEndpoint = url;
+
+    		return config;
+  });
+}
+
+module.exports = function withAppsFlyerIos(config, shouldUseStrictMode, skanEndpoint) {
 	config = withPodfile(config, shouldUseStrictMode);
 	config = withAppsFlyerAppDelegate(config);
+	config = withPlistAdvertisingAttribution(config, skanEndpoint)
 	return config;
 };

--- a/expo/withAppsFlyerIos.js
+++ b/expo/withAppsFlyerIos.js
@@ -8,6 +8,7 @@ const RNAPPSFLYER_CONTINUE_USER_ACTIVITY_IDENTIFIER = `- (BOOL)application:(UIAp
 const RNAPPSFLYER_OPENURL_IDENTIFIER = `- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {`;
 const RNAPPSFLYER_CONTINUE_USER_ACTIVITY_CODE = `[[AppsFlyerAttribution shared] continueUserActivity:userActivity restorationHandler:restorationHandler];\n`;
 const RNAPPSFLYER_OPENURL_CODE = `[[AppsFlyerAttribution shared] handleOpenUrl:url options:options];\n`;
+const RNAPPSFLYER_ATTRIBUTION_ENDPOINT = 'https://appsflyer-skadnetwork.com/';
 
 function modifyAppDelegate(appDelegate) {
 	if (!appDelegate.includes(RNAPPSFLYER_IMPORT)) {
@@ -67,10 +68,10 @@ function withPodfile(config, shouldUseStrictMode) {
 	]);
 }
 
-function withPlistAdvertisingAttribution(config, url) {
+function withPlistAdvertisingAttribution(config) {
 	  return withInfoPlist(config, async config => {
     		const infoPlist = config.modResults;
-    		infoPlist.NSAdvertisingAttributionReportEndpoint = url;
+    		infoPlist.NSAdvertisingAttributionReportEndpoint = RNAPPSFLYER_ATTRIBUTION_ENDPOINT;
 
     		return config;
   });
@@ -78,7 +79,7 @@ function withPlistAdvertisingAttribution(config, url) {
 
 module.exports = function withAppsFlyerIos(config, shouldUseStrictMode, skanEndpoint) {
 	config = withPodfile(config, shouldUseStrictMode);
-	config = withAppsFlyerAppDelegate(config);
-	config = withPlistAdvertisingAttribution(config, skanEndpoint)
+	config = withAppsFlyerAppDelegate(config);	
+	config = withPlistAdvertisingAttribution(config);
 	return config;
 };

--- a/expo/withAppsFlyerIos.js
+++ b/expo/withAppsFlyerIos.js
@@ -1,4 +1,4 @@
-const { withDangerousMod, withAppDelegate, WarningAggregator } = require('@expo/config-plugins');
+const { withDangerousMod, withAppDelegate, WarningAggregator, withInfoPlist } = require('@expo/config-plugins');
 const { mergeContents } = require('@expo/config-plugins/build/utils/generateCode');
 const fs = require('fs');
 const path = require('path');


### PR DESCRIPTION
I've just had to write my own expo plugin to add the `NSAdvertisingAttributionReportEndpoint` value to info.plist in a React Native project - and I figured I might as well attempt to get that into this package as I think it should be supported out of the box.

The PR is not 100% ready to go because I think there's questions that needs answering first: 

1. Should the endpoint URL be hardcoded to https://appsflyer-skadnetwork.com or should the value be provided via the plugin config?
2. Should this be an optional configuration?