### PR TITLE
 add on new intent override plugin for expo android

### DIFF
--- a/expo/withAppsFlyer.js
+++ b/expo/withAppsFlyer.js
@@ -1,5 +1,8 @@
 const withAppsFlyerIos = require('./withAppsFlyerIos');
+const withAppsFlyerAndroid = require('./withAppsFlyerAndroid');
+
 module.exports = function withAppsFlyer(config, { shouldUseStrictMode = false }) {
 	config = withAppsFlyerIos(config, shouldUseStrictMode);
+	config = withAppsFlyerAndroid(config)
 	return config;
 };

--- a/expo/withAppsFlyerAndroid.js
+++ b/expo/withAppsFlyerAndroid.js
@@ -2,7 +2,7 @@ const {withMainActivity} = require('@expo/config-plugins')
 
 function overrideOnNewIntent(contents, packageName = ''){
     let nextContent = contents
-    const intentImportString = 'import android.content.intent'
+    const intentImportString = 'import android.content.Intent'
 
     if (!nextContent.includes(intentImportString)){
         const packageString = `${packageName}\n`

--- a/expo/withAppsFlyerAndroid.js
+++ b/expo/withAppsFlyerAndroid.js
@@ -1,0 +1,32 @@
+const {withMainActivity} = require('@expo/config-plugins')
+
+function overrideOnNewIntent(contents, packageName = ''){
+    let nextContent = contents
+    const intentImportString = 'import android.content.intent'
+
+    if (!nextContent.includes(intentImportString)){
+        const packageString = `${packageName}\n`
+        nextContent = nextContent.replace(packageString,`${packageString}\n${intentImportString}`)
+    }
+
+    if (!nextContent.includes('override fun onNewIntent(intent: Intent?)')) {
+        const classDeclarationRegex = /class\s+\w+.*\{/
+        nextContent = nextContent.replace(
+            classDeclarationRegex,
+            match=>`${match}
+  override fun onNewIntent(intent: Intent?) {
+    super.onNewIntent(intent)
+    setIntent(intent)
+  }      
+`)
+    }
+    return nextContent
+}
+
+module.exports = function withAppsFlyerAndroid(config){
+    return withMainActivity(config, function(config){
+        const {modResults:{contents},android} = config
+        config.modResults.contents = overrideOnNewIntent(contents,android?.package)
+        return config
+    })
+}


### PR DESCRIPTION
In reaction to this issue https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/558 and this closed PR https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/pull/559. 

This adds the;

```kt
import android.content.intent

override fun onNewIntent(intent: Intent?) {
    super.onNewIntent(intent)
    setIntent(intent)
  }
```
by default if `import android.content.intent` is not already in `MainActivity` and if `override fun onNewIntent(intent: Intent?)` is not already implemented. 


This ultimately resolves issue with expo android not opening deeplinks when app is in background

cc: @iway1
