### PR TITLE
A 6.16.0 update and minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,3 @@
-## 6.16.0
-Release date: *2025-02-23*
-
-### Android
-- Updated Android minimum SDK version to 21.
-- Updated Gradle to 8.2.0 in demo app for testing and added `namespace` in `android/build.gradle` ([#583](https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/583), [#561](https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/561)).
-- Updated Expo documentation with `customAndroidManifest` to overcome build failure with React Native 0.76 & Expo 52 ([#586](https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/586#issuecomment-2520223121)).
-- Fixed typo in UDL type definition ([#575](https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/575)).
-- Fixed typo in mediation network `[logAdRevenue]` for both Android and iOS.
-
-### iOS
-- Fixed `anonymizeUser` boolean bug related to New Architecture ([#584](https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/584)).
-- Fixed a conflict with the `SUCCESS` symbol declared in another third-party library (New Architecture & React Native 0.76) ([#596](https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/pull/596)).
-- Updated import typo related to AFAdRevenueData ([#602](https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/602)).
-- Fixed other boolean values to pass by value instead of reference.
-
 ## 6.15.3
  Release date: *2025-01-8*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Release date: *2025-02-23*
 
 ### Android
+- Updated Android minimum SDK version to 21.
 - Updated Gradle to 8.2.0 in demo app for testing and added `namespace` in `android/build.gradle` ([#583](https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/583), [#561](https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/561)).
 - Updated Expo documentation with `customAndroidManifest` to overcome build failure with React Native 0.76 & Expo 52 ([#586](https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/586#issuecomment-2520223121)).
 - Fixed typo in UDL type definition ([#575](https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/575)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 6.16.0
+Release date: *2025-02-23*
+
+### Android
+- Updated Gradle to 8.2.0 in demo app for testing and added `namespace` in `android/build.gradle` ([#583](https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/583), [#561](https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/561)).
+- Updated Expo documentation with `customAndroidManifest` to overcome build failure with React Native 0.76 & Expo 52 ([#586](https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/586#issuecomment-2520223121)).
+- Fixed typo in UDL type definition ([#575](https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/575)).
+- Fixed typo in mediation network `[logAdRevenue]` for both Android and iOS.
+
+### iOS
+- Fixed `anonymizeUser` boolean bug related to New Architecture ([#584](https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/584)).
+- Fixed a conflict with the `SUCCESS` symbol declared in another third-party library (New Architecture & React Native 0.76) ([#596](https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/pull/596)).
+- Updated import typo related to AFAdRevenueData ([#602](https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/602)).
+- Fixed other boolean values to pass by value instead of reference.
+
 ## 6.15.3
  Release date: *2025-01-8*
 

--- a/android/.project
+++ b/android/.project
@@ -6,18 +6,12 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
-			<name>org.eclipse.jdt.core.javabuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
 			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
 	<filteredResources>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,11 +20,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
+    namespace "com.appsflyer.reactnative"
     compileSdkVersion safeExtGet('compileSdkVersion', 34)
     buildToolsVersion safeExtGet('buildToolsVersion', '34.0.0')
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 16)
+        minSdkVersion safeExtGet('minSdkVersion', 21)
         targetSdkVersion safeExtGet('targetSdkVersion', 34)
         versionCode 1
         versionName "1.0"
@@ -54,5 +55,5 @@ repositories {
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
     implementation "com.android.installreferrer:installreferrer:${safeExtGet('installReferrerVersion', '2.1')}"
-    api "com.appsflyer:af-android-sdk:${safeExtGet('appsflyerVersion', '6.15.2')}"
+    api "com.appsflyer:af-android-sdk:${safeExtGet('appsflyerVersion', '6.16.0')}"
 }

--- a/android/src/main/java/com/appsflyer/reactnative/RNAppsFlyerConstants.java
+++ b/android/src/main/java/com/appsflyer/reactnative/RNAppsFlyerConstants.java
@@ -6,7 +6,7 @@ package com.appsflyer.reactnative;
 
 public class RNAppsFlyerConstants {
 
-    final static String PLUGIN_VERSION = "6.15.3";
+    final static String PLUGIN_VERSION = "6.16.0";
     final static String NO_DEVKEY_FOUND = "No 'devKey' found or its empty";
     final static String UNKNOWN_ERROR = "AF Unknown Error";
     final static String SUCCESS = "Success";

--- a/demos/appsflyer-react-native-app/android/app/build.gradle
+++ b/demos/appsflyer-react-native-app/android/app/build.gradle
@@ -148,6 +148,7 @@ android {
             keyPassword 'android'
         }
     }
+    namespace 'com.appsflyerexample'
     buildTypes {
         debug {
             signingConfig signingConfigs.debug

--- a/demos/appsflyer-react-native-app/android/build.gradle
+++ b/demos/appsflyer-react-native-app/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
     dependencies {
         //classpath("com.android.tools.build:gradle:4.2.1")
-        classpath("com.android.tools.build:gradle:7.1.3")
+        classpath('com.android.tools.build:gradle:8.2.0')
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/demos/appsflyer-react-native-app/android/gradle.properties
+++ b/demos/appsflyer-react-native-app/android/gradle.properties
@@ -26,3 +26,6 @@ android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.93.0
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/demos/appsflyer-react-native-app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/demos/appsflyer-react-native-app/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Sep 01 10:19:20 IDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/demos/appsflyer-react-native-app/components/AppsFlyer.js
+++ b/demos/appsflyer-react-native-app/components/AppsFlyer.js
@@ -40,7 +40,7 @@ export function AFLogEvent(name, values) {
 export function AFLogAdRevenue(){
   const adRevenueData = {
     monetizationNetwork: 'AF-AdNetwork',
-    mediationNetwork: MEDIATION_NETWORK.IRONSOURCE,
+    mediationNetwork: MEDIATION_NETWORK.DIRECT_MONETIZATION_NETWORK,
     currencyIso4217Code: 'USD',
     revenue: 1.23, 
     additionalParameters : {

--- a/demos/appsflyer-react-native-app/components/AppsFlyer.js
+++ b/demos/appsflyer-react-native-app/components/AppsFlyer.js
@@ -21,7 +21,12 @@ const initOptions = {
 export function AFInit() {
   if (Platform.OS == 'ios') {
     appsFlyer.setCurrentDeviceLanguage("EN");
+    appsFlyer.disableSKAD(true);
   }
+
+  appsFlyer.anonymizeUser(true);
+  appsFlyer.enableTCFDataCollection(true);
+
   appsFlyer.setAppInviteOneLinkID('oW4R');
   appsFlyer.initSdk(initOptions, null, null);
 }

--- a/demos/appsflyer-react-native-app/ios/AppsFlyerExample.xcodeproj/project.pbxproj
+++ b/demos/appsflyer-react-native-app/ios/AppsFlyerExample.xcodeproj/project.pbxproj
@@ -11,10 +11,10 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		758FBD406B8A60C781CB65C7 /* libPods-AppsFlyerExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3772C10A05F15474D2AE8E5B /* libPods-AppsFlyerExample.a */; };
+		16B4DFEB0C59658B8FE94085 /* libPods-AppsFlyerExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D28800373012A08DB5A8DA9B /* libPods-AppsFlyerExample.a */; };
 		7EEAAD9F2D2D7980006F2316 /* main.jsbundle in Resources */ = {isa = PBXBuildFile; fileRef = 7EEAAD9E2D2D7980006F2316 /* main.jsbundle */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		8A99A8955B526C01707AFBFA /* libPods-AppsFlyerExample-AppsFlyerExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C982642725666DF8D1E1F96 /* libPods-AppsFlyerExample-AppsFlyerExampleTests.a */; };
+		9814E2884017CE2F8F3BAA9E /* libPods-AppsFlyerExample-AppsFlyerExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 972E1865E201F523B65B5135 /* libPods-AppsFlyerExample-AppsFlyerExampleTests.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -37,14 +37,14 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = AppsFlyerExample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = AppsFlyerExample/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = AppsFlyerExample/main.m; sourceTree = "<group>"; };
-		1C982642725666DF8D1E1F96 /* libPods-AppsFlyerExample-AppsFlyerExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AppsFlyerExample-AppsFlyerExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		3772C10A05F15474D2AE8E5B /* libPods-AppsFlyerExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AppsFlyerExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		5CAE30CF50FDE233EFB84891 /* Pods-AppsFlyerExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppsFlyerExample.release.xcconfig"; path = "Target Support Files/Pods-AppsFlyerExample/Pods-AppsFlyerExample.release.xcconfig"; sourceTree = "<group>"; };
+		243DD5E4FB76F2C1D4E83B8C /* Pods-AppsFlyerExample-AppsFlyerExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppsFlyerExample-AppsFlyerExampleTests.release.xcconfig"; path = "Target Support Files/Pods-AppsFlyerExample-AppsFlyerExampleTests/Pods-AppsFlyerExample-AppsFlyerExampleTests.release.xcconfig"; sourceTree = "<group>"; };
 		7EEAAD9E2D2D7980006F2316 /* main.jsbundle */ = {isa = PBXFileReference; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = AppsFlyerExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		BE4C6B4402435E3245DA5B5C /* Pods-AppsFlyerExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppsFlyerExample.debug.xcconfig"; path = "Target Support Files/Pods-AppsFlyerExample/Pods-AppsFlyerExample.debug.xcconfig"; sourceTree = "<group>"; };
-		C6E030350442BE719CA4C6F7 /* Pods-AppsFlyerExample-AppsFlyerExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppsFlyerExample-AppsFlyerExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-AppsFlyerExample-AppsFlyerExampleTests/Pods-AppsFlyerExample-AppsFlyerExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
-		E3122EACB4600C968024FA8D /* Pods-AppsFlyerExample-AppsFlyerExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppsFlyerExample-AppsFlyerExampleTests.release.xcconfig"; path = "Target Support Files/Pods-AppsFlyerExample-AppsFlyerExampleTests/Pods-AppsFlyerExample-AppsFlyerExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		972E1865E201F523B65B5135 /* libPods-AppsFlyerExample-AppsFlyerExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AppsFlyerExample-AppsFlyerExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B7C25798B6EC8E96E5D5E977 /* Pods-AppsFlyerExample-AppsFlyerExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppsFlyerExample-AppsFlyerExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-AppsFlyerExample-AppsFlyerExampleTests/Pods-AppsFlyerExample-AppsFlyerExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		C1DAD76DB0BD48A6B530766A /* Pods-AppsFlyerExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppsFlyerExample.debug.xcconfig"; path = "Target Support Files/Pods-AppsFlyerExample/Pods-AppsFlyerExample.debug.xcconfig"; sourceTree = "<group>"; };
+		D28800373012A08DB5A8DA9B /* libPods-AppsFlyerExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AppsFlyerExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E902941ACBB56BA6DAD27906 /* Pods-AppsFlyerExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppsFlyerExample.release.xcconfig"; path = "Target Support Files/Pods-AppsFlyerExample/Pods-AppsFlyerExample.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		EDCF29CA26F74C8F000729D4 /* AppsFlyerExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = AppsFlyerExample.entitlements; path = AppsFlyerExample/AppsFlyerExample.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -54,7 +54,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8A99A8955B526C01707AFBFA /* libPods-AppsFlyerExample-AppsFlyerExampleTests.a in Frameworks */,
+				9814E2884017CE2F8F3BAA9E /* libPods-AppsFlyerExample-AppsFlyerExampleTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -62,7 +62,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				758FBD406B8A60C781CB65C7 /* libPods-AppsFlyerExample.a in Frameworks */,
+				16B4DFEB0C59658B8FE94085 /* libPods-AppsFlyerExample.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -104,8 +104,8 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				3772C10A05F15474D2AE8E5B /* libPods-AppsFlyerExample.a */,
-				1C982642725666DF8D1E1F96 /* libPods-AppsFlyerExample-AppsFlyerExampleTests.a */,
+				D28800373012A08DB5A8DA9B /* libPods-AppsFlyerExample.a */,
+				972E1865E201F523B65B5135 /* libPods-AppsFlyerExample-AppsFlyerExampleTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -113,10 +113,10 @@
 		82A9707B82F91C9BFF6E0016 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				BE4C6B4402435E3245DA5B5C /* Pods-AppsFlyerExample.debug.xcconfig */,
-				5CAE30CF50FDE233EFB84891 /* Pods-AppsFlyerExample.release.xcconfig */,
-				C6E030350442BE719CA4C6F7 /* Pods-AppsFlyerExample-AppsFlyerExampleTests.debug.xcconfig */,
-				E3122EACB4600C968024FA8D /* Pods-AppsFlyerExample-AppsFlyerExampleTests.release.xcconfig */,
+				C1DAD76DB0BD48A6B530766A /* Pods-AppsFlyerExample.debug.xcconfig */,
+				E902941ACBB56BA6DAD27906 /* Pods-AppsFlyerExample.release.xcconfig */,
+				B7C25798B6EC8E96E5D5E977 /* Pods-AppsFlyerExample-AppsFlyerExampleTests.debug.xcconfig */,
+				243DD5E4FB76F2C1D4E83B8C /* Pods-AppsFlyerExample-AppsFlyerExampleTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -160,11 +160,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "AppsFlyerExampleTests" */;
 			buildPhases = (
-				C53414E99C4F14C38D0D0800 /* [CP] Check Pods Manifest.lock */,
+				8C336900FBF98A09883FEC01 /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
-				886093803E0B787FACAB784A /* [CP] Copy Pods Resources */,
+				71CF15671A05027D181E465D /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -180,13 +180,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "AppsFlyerExample" */;
 			buildPhases = (
-				D9F717B1F4B3A05EA3D95AA4 /* [CP] Check Pods Manifest.lock */,
+				E648CA8DA0983B03CF409A07 /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				4721923C614EE6D1A58C11F1 /* [CP] Copy Pods Resources */,
+				4A2AC6477284DB4BDF137B9C /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -269,7 +269,7 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nexport NODE_BINARY=/usr/local/bin/node\n";
 		};
-		4721923C614EE6D1A58C11F1 /* [CP] Copy Pods Resources */ = {
+		4A2AC6477284DB4BDF137B9C /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -286,7 +286,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AppsFlyerExample/Pods-AppsFlyerExample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		886093803E0B787FACAB784A /* [CP] Copy Pods Resources */ = {
+		71CF15671A05027D181E465D /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -303,7 +303,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AppsFlyerExample-AppsFlyerExampleTests/Pods-AppsFlyerExample-AppsFlyerExampleTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C53414E99C4F14C38D0D0800 /* [CP] Check Pods Manifest.lock */ = {
+		8C336900FBF98A09883FEC01 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -325,7 +325,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D9F717B1F4B3A05EA3D95AA4 /* [CP] Check Pods Manifest.lock */ = {
+		E648CA8DA0983B03CF409A07 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -399,7 +399,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C6E030350442BE719CA4C6F7 /* Pods-AppsFlyerExample-AppsFlyerExampleTests.debug.xcconfig */;
+			baseConfigurationReference = B7C25798B6EC8E96E5D5E977 /* Pods-AppsFlyerExample-AppsFlyerExampleTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -427,7 +427,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E3122EACB4600C968024FA8D /* Pods-AppsFlyerExample-AppsFlyerExampleTests.release.xcconfig */;
+			baseConfigurationReference = 243DD5E4FB76F2C1D4E83B8C /* Pods-AppsFlyerExample-AppsFlyerExampleTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
@@ -452,7 +452,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BE4C6B4402435E3245DA5B5C /* Pods-AppsFlyerExample.debug.xcconfig */;
+			baseConfigurationReference = C1DAD76DB0BD48A6B530766A /* Pods-AppsFlyerExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -482,7 +482,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5CAE30CF50FDE233EFB84891 /* Pods-AppsFlyerExample.release.xcconfig */;
+			baseConfigurationReference = E902941ACBB56BA6DAD27906 /* Pods-AppsFlyerExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/demos/appsflyer-react-native-app/ios/AppsFlyerExample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/demos/appsflyer-react-native-app/ios/AppsFlyerExample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/demos/appsflyer-react-native-app/package.json
+++ b/demos/appsflyer-react-native-app/package.json
@@ -14,7 +14,7 @@
     "@react-navigation/stack": "^6.0.7",
     "react": "18.1.0",
     "react-native": "0.70.6",
-    "react-native-appsflyer": "file:../../",
+    "react-native-appsflyer": "../../",
     "react-native-elements": "^3.4.2",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-safe-area-context": "^3.3.2",

--- a/expo/withAppsFlyer.js
+++ b/expo/withAppsFlyer.js
@@ -1,5 +1,5 @@
 const withAppsFlyerIos = require('./withAppsFlyerIos');
-module.exports = function withAppsFlyer(config, { shouldUseStrictMode = false }) {
+module.exports = function withAppsFlyer(config, { shouldUseStrictMode = false } = {}) {
 	config = withAppsFlyerIos(config, shouldUseStrictMode);
 	return config;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,7 +50,7 @@ declare module "react-native-appsflyer" {
     export type UnifiedDeepLinkData = {
         status: "success" | "failure",
         type: "onDeepLinking",
-        deepLinkStatus: 'FOUND' | 'NOT_FOUND' | 'Error',
+        deepLinkStatus: 'FOUND' | 'NOT_FOUND' | 'ERROR',
         isDeferred: boolean,
         data: {
             campaign: string;

--- a/index.js
+++ b/index.js
@@ -60,8 +60,8 @@ appsFlyer.logEvent = logEvent;
 
 export const MEDIATION_NETWORK = Object.freeze({
 	IRONSOURCE : "ironsource",
-	APPLOVIN_MAX : "applovinmax",
-	GOOGLE_ADMOB : "googleadmob",
+	APPLOVIN_MAX : "applovin_max",
+	GOOGLE_ADMOB : "google_admob",
 	FYBER : "fyber",
 	APPODEAL : "appodeal",
 	ADMOST : "Admost",
@@ -70,9 +70,9 @@ export const MEDIATION_NETWORK = Object.freeze({
 	YANDEX : "Yandex",
 	CHARTBOOST : "chartboost",
 	UNITY : "Unity",
-	TOPON_PTE : "toponpte",
-	CUSTOM_MEDIATION : "customMediation",
-	DIRECT_MONETIZATION_NETWORK : "directMonetizationNetwork"
+	TOPON_PTE : "topon_pte",
+	CUSTOM_MEDIATION : "custom_mediation",
+	DIRECT_MONETIZATION_NETWORK : "direct_monetization_network"
 });
 
 function logAdRevenue(adRevenueData) {

--- a/ios/AppsFlyerLib.h
+++ b/ios/AppsFlyerLib.h
@@ -13,7 +13,7 @@
 #import <AppsFlyerLib/AppsFlyerDeepLinkResult.h>
 #import <AppsFlyerLib/AppsFlyerDeepLink.h>
 #import <AppsFlyerLib/AppsFlyerConsent.h>
-#import <AppsFlyerLib/AppsFlyerAdRevenueData.h>
+#import <AppsFlyerLib/AFAdRevenueData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ios/RNAppsFlyer.h
+++ b/ios/RNAppsFlyer.h
@@ -27,7 +27,7 @@ static NSString *const NO_DEVKEY_FOUND              = @"No 'devKey' found or its
 static NSString *const NO_APPID_FOUND               = @"No 'appId' found or its empty";
 static NSString *const NO_EVENT_NAME_FOUND          = @"No 'eventName' found or its empty";
 static NSString *const EMPTY_OR_CORRUPTED_LIST      = @"No arguments found or list is corrupted";
-static NSString *const SUCCESS                      = @"Success";
+static NSString *const AF_SUCCESS                   = @"Success";
 static NSString *const INVALID_URI                  = @"Invalid URI";
 static NSString *const IOS_14_ONLY                  = @"Feature only supported on iOS 14 and above";
 

--- a/ios/RNAppsFlyer.h
+++ b/ios/RNAppsFlyer.h
@@ -22,7 +22,7 @@
 @end
 
 
-static NSString *const kAppsFlyerPluginVersion      = @"6.15.3";
+static NSString *const kAppsFlyerPluginVersion      = @"6.16.0";
 static NSString *const NO_DEVKEY_FOUND              = @"No 'devKey' found or its empty";
 static NSString *const NO_APPID_FOUND               = @"No 'appId' found or its empty";
 static NSString *const NO_EVENT_NAME_FOUND          = @"No 'eventName' found or its empty";

--- a/ios/RNAppsFlyer.m
+++ b/ios/RNAppsFlyer.m
@@ -14,7 +14,7 @@ RCT_EXPORT_METHOD(initSdkWithCallBack: (NSDictionary*)initSdkOptions
     NSError* error = nil;
     error = [self callSdkInternal:initSdkOptions];
     if (error == nil){
-        successCallback(@[SUCCESS]);
+        successCallback(@[AF_SUCCESS]);
     }else{
         errorCallback(error);
     }
@@ -27,7 +27,7 @@ RCT_EXPORT_METHOD(initSdkWithPromise: (NSDictionary*)initSdkOptions
     NSError* error = nil;
     error = [self callSdkInternal:initSdkOptions];
     if (error == nil){
-        resolve(@[SUCCESS]);
+        resolve(@[AF_SUCCESS]);
     }else{
         reject([NSString stringWithFormat: @"%ld", (long)error.code], error.domain, error);    }
 }
@@ -141,7 +141,7 @@ RCT_EXPORT_METHOD(logEvent: (NSString *)eventName eventValues:(NSDictionary *)ev
             errorCallback(@[error.localizedDescription]);
             return;
         }
-        successCallback(@[SUCCESS]);
+        successCallback(@[AF_SUCCESS]);
     }];
 }
 
@@ -159,7 +159,7 @@ RCT_EXPORT_METHOD(logEventWithPromise: (NSString *)eventName eventValues:(NSDict
             reject([NSString stringWithFormat: @"%ld", (long)error.code], error.domain, error);
             return;
         }
-        resolve(@[SUCCESS]);
+        resolve(@[AF_SUCCESS]);
     }];
 }
 
@@ -238,18 +238,18 @@ RCT_EXPORT_METHOD(getAppsFlyerUID: (RCTResponseSenderBlock)callback) {
 
 RCT_EXPORT_METHOD(setCustomerUserId: (NSString *)userId callback:(RCTResponseSenderBlock)callback) {
     [[AppsFlyerLib shared] setCustomerUserID:userId];
-    callback(@[SUCCESS]);
+    callback(@[AF_SUCCESS]);
 }
 
 RCT_EXPORT_METHOD(stop: (BOOL)isStopped callback:(RCTResponseSenderBlock)callback) {
     [AppsFlyerLib shared].isStopped  = isStopped;
-     callback(@[SUCCESS]);
+     callback(@[AF_SUCCESS]);
 }
 
 RCT_EXPORT_METHOD(logLocation: (double)longitude latitude:(double)latitude callback:(RCTResponseSenderBlock)callback) {
     [[AppsFlyerLib shared] logLocation:longitude latitude:latitude];
     NSArray *events = @[[NSNumber numberWithDouble:longitude], [NSNumber numberWithDouble:latitude]];
-    callback(@[SUCCESS, events]);
+    callback(@[AF_SUCCESS, events]);
 }
 
 RCT_EXPORT_METHOD(setUserEmails: (NSDictionary*)options
@@ -288,7 +288,7 @@ RCT_EXPORT_METHOD(setUserEmails: (NSDictionary*)options
     }
     else{
         [[AppsFlyerLib shared] setUserEmails:emails withCryptType:emailsCryptType];
-        successCallback(@[SUCCESS]);
+        successCallback(@[AF_SUCCESS]);
     }
 }
 
@@ -301,19 +301,19 @@ RCT_EXPORT_METHOD(setUserEmails: (NSDictionary*)options
 
 RCT_EXPORT_METHOD(setAdditionalData: (NSDictionary *)additionalData callback:(RCTResponseSenderBlock)callback) {
     [[AppsFlyerLib shared] setAdditionalData:additionalData];
-    callback(@[SUCCESS]);
+    callback(@[AF_SUCCESS]);
 }
 
 //USER INVITES
 
 RCT_EXPORT_METHOD(setAppInviteOneLinkID: (NSString *)oneLinkID callback:(RCTResponseSenderBlock)callback) {
     [AppsFlyerLib shared].appInviteOneLinkID = oneLinkID;
-    callback(@[SUCCESS]);
+    callback(@[AF_SUCCESS]);
 }
 
 RCT_EXPORT_METHOD(setCurrencyCode: (NSString *)currencyCode callback:(RCTResponseSenderBlock)callback) {
     [[AppsFlyerLib shared] setCurrencyCode:currencyCode];
-     callback(@[SUCCESS]);
+     callback(@[AF_SUCCESS]);
 }
 
 RCT_EXPORT_METHOD(generateInviteLink: (NSDictionary *)inviteLinkOptions
@@ -501,7 +501,7 @@ RCT_EXPORT_METHOD(logCrossPromotionAndOpenStore: (NSString *)appID
 
 RCT_EXPORT_METHOD(anonymizeUser: (BOOL)b callback:(RCTResponseSenderBlock)callback) {
     [AppsFlyerLib shared].anonymizeUser = b;
-    callback(@[SUCCESS]);
+    callback(@[AF_SUCCESS]);
 }
 
 RCT_EXPORT_METHOD(updateServerUninstallToken: (NSString *)deviceToken callback:(RCTResponseSenderBlock)callback) {
@@ -517,21 +517,21 @@ RCT_EXPORT_METHOD(updateServerUninstallToken: (NSString *)deviceToken callback:(
         [deviceTokenData appendBytes:&whole_byte length:1];
     }
     [[AppsFlyerLib shared] registerUninstall:deviceTokenData];
-    callback(@[SUCCESS]);
+    callback(@[AF_SUCCESS]);
 }
 
 RCT_EXPORT_METHOD(setOneLinkCustomDomains:(NSArray *) domains
                   successCallback :(RCTResponseSenderBlock)successCallback
                   errorCallback:(RCTResponseErrorBlock)errorCallback) {
     [[AppsFlyerLib shared] setOneLinkCustomDomains:domains];
-    successCallback(@[SUCCESS]);
+    successCallback(@[AF_SUCCESS]);
 }
 
 RCT_EXPORT_METHOD(setResolveDeepLinkURLs:(NSArray *) urls
                   successCallback :(RCTResponseSenderBlock)successCallback
                   errorCallback:(RCTResponseErrorBlock)errorCallback) {
     [[AppsFlyerLib shared] setResolveDeepLinkURLs:urls];
-    successCallback(@[SUCCESS]);
+    successCallback(@[AF_SUCCESS]);
 }
 
 RCT_EXPORT_METHOD(performOnAppAttribution:(NSString *) urlString
@@ -543,7 +543,7 @@ RCT_EXPORT_METHOD(performOnAppAttribution:(NSString *) urlString
         errorCallback(error);
     } else {
         [[AppsFlyerLib shared] performOnAppAttributionWithURL:url];
-        successCallback(@[SUCCESS]);
+        successCallback(@[AF_SUCCESS]);
     }
 }
 
@@ -606,16 +606,16 @@ RCT_EXPORT_METHOD(sendPushNotificationData: (NSDictionary*)pushPayload errorCall
 
 RCT_EXPORT_METHOD(setHost: (NSString*)hostPrefix hostName: (NSString*)hostName successCallback :(RCTResponseSenderBlock)successCallback) {
     [[AppsFlyerLib shared] setHost:hostName withHostPrefix:hostPrefix];
-    successCallback(@[SUCCESS]);
+    successCallback(@[AF_SUCCESS]);
 }
 
 RCT_EXPORT_METHOD(addPushNotificationDeepLinkPath: (NSArray*)path successCallback :(RCTResponseSenderBlock)successCallback
                   errorCallback:(RCTResponseErrorBlock)errorCallback) {
     [[AppsFlyerLib shared] addPushNotificationDeepLinkPath: path];
-    successCallback(@[SUCCESS]);
+    successCallback(@[AF_SUCCESS]);
 }
 
-RCT_EXPORT_METHOD(disableSKAD: (BOOL *)b ) {
+RCT_EXPORT_METHOD(disableSKAD: (BOOL)b ) {
     [AppsFlyerLib shared].disableSKAdNetwork = b;
     if (b){
         NSLog(@"[DEBUG] AppsFlyer: SKADNetwork is disabled");
@@ -636,7 +636,7 @@ RCT_EXPORT_METHOD(appendParametersToDeepLinkingURL:(NSString *)contains partnerD
     [[AppsFlyerLib shared] appendParametersToDeepLinkingURLWithString:contains parameters:parameters];
 }
 
-RCT_EXPORT_METHOD(enableTCFDataCollection:(BOOL *)enabled) {
+RCT_EXPORT_METHOD(enableTCFDataCollection:(BOOL)enabled) {
     [[AppsFlyerLib shared] enableTCFDataCollection:enabled];
 }
 

--- a/ios/RNAppsFlyer.m
+++ b/ios/RNAppsFlyer.m
@@ -196,9 +196,9 @@ RCT_EXPORT_METHOD(logAdRevenue:(NSDictionary *)adRevenueDictionary)
     
     // Use literals to map the mediation network string to the corresponding enum value
     NSDictionary<NSString *, NSNumber *> *mediationNetworkMappings = @{
-        @"googleadmob": @(AppsFlyerAdRevenueMediationNetworkTypeGoogleAdMob),
+        @"google_admob": @(AppsFlyerAdRevenueMediationNetworkTypeGoogleAdMob),
         @"ironsource": @(AppsFlyerAdRevenueMediationNetworkTypeIronSource),
-        @"applovinmax": @(AppsFlyerAdRevenueMediationNetworkTypeApplovinMax),
+        @"applovin_max": @(AppsFlyerAdRevenueMediationNetworkTypeApplovinMax),
         @"fyber": @(AppsFlyerAdRevenueMediationNetworkTypeFyber),
         @"appodeal": @(AppsFlyerAdRevenueMediationNetworkTypeAppodeal),
         @"admost": @(AppsFlyerAdRevenueMediationNetworkTypeAdmost),
@@ -207,9 +207,9 @@ RCT_EXPORT_METHOD(logAdRevenue:(NSDictionary *)adRevenueDictionary)
         @"yandex": @(AppsFlyerAdRevenueMediationNetworkTypeYandex),
         @"chartboost": @(AppsFlyerAdRevenueMediationNetworkTypeChartBoost),
         @"unity": @(AppsFlyerAdRevenueMediationNetworkTypeUnity),
-        @"toponpte": @(AppsFlyerAdRevenueMediationNetworkTypeToponPte),
-        @"custom": @(AppsFlyerAdRevenueMediationNetworkTypeCustom),
-        @"directmonetization": @(AppsFlyerAdRevenueMediationNetworkTypeDirectMonetization),
+        @"topon_pte": @(AppsFlyerAdRevenueMediationNetworkTypeToponPte),
+        @"custom_mediation": @(AppsFlyerAdRevenueMediationNetworkTypeCustom),
+        @"direct_monetization_network": @(AppsFlyerAdRevenueMediationNetworkTypeDirectMonetization),
     };
     
     NSNumber *mediationNetworkEnumNumber = mediationNetworkMappings[mediationNetworkString.lowercaseString];

--- a/ios/RNAppsFlyer.m
+++ b/ios/RNAppsFlyer.m
@@ -499,7 +499,7 @@ RCT_EXPORT_METHOD(logCrossPromotionAndOpenStore: (NSString *)appID
     return NSClassFromString(@"EXAppDelegateWrapper") != nil;
 }
 
-RCT_EXPORT_METHOD(anonymizeUser: (BOOL *)b callback:(RCTResponseSenderBlock)callback) {
+RCT_EXPORT_METHOD(anonymizeUser: (BOOL)b callback:(RCTResponseSenderBlock)callback) {
     [AppsFlyerLib shared].anonymizeUser = b;
     callback(@[SUCCESS]);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-appsflyer",
-  "version": "6.15.3",
+  "version": "6.16.0",
   "description": "React Native Appsflyer plugin",
   "main": "index.js",
   "types": "index.d.ts",

--- a/react-native-appsflyer.podspec
+++ b/react-native-appsflyer.podspec
@@ -18,13 +18,13 @@ Pod::Spec.new do |s|
   # AppsFlyerFramework
   if defined?($RNAppsFlyerStrictMode) && ($RNAppsFlyerStrictMode == true)
     Pod::UI.puts "#{s.name}: Using AppsFlyerFramework/Strict mode"
-    s.dependency 'AppsFlyerFramework/Strict', '6.15.3'
+    s.dependency 'AppsFlyerFramework/Strict', '6.16.0'
     s.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) AFSDK_NO_IDFA=1' }
   else
     if !defined?($RNAppsFlyerStrictMode)
       Pod::UI.puts "#{s.name}: Using default AppsFlyerFramework. You may require App Tracking Transparency. Not allowed for Kids apps."
       Pod::UI.puts "#{s.name}: You may set variable `$RNAppsFlyerStrictMode=true` in Podfile to use strict mode for kids apps."
     end
-    s.dependency 'AppsFlyerFramework', '6.15.3'
+    s.dependency 'AppsFlyerFramework', '6.16.0'
   end
 end


### PR DESCRIPTION
- Android: Updating sample app AGP to 8.2.0 for testing and adding namespace in android/build.gradle.
- Android: Updating minimum SDK version to 21.
- RN Docs: Updating expo documentation with customAndroidManifest to overcome build failure with RN 0.76 & Expo 52.
- RN: Updating UDL type typo
- iOS: Fixing a conflict with the 'SUCCESS' symbol declared in another third-party library. [Related to newArch and RN 0.76]
- iOS: Update import typo
- iOS: Fixing anonymizeUser,disableSKAD,enableTCFDatacollection boolean bug with newArch to pass by value and not by reference
