### PR TITLE
Downgrade gradle + doc about fix.

### DIFF
--- a/Docs/RN_Installation.md
+++ b/Docs/RN_Installation.md
@@ -137,6 +137,45 @@ So `getPackages()` should look like:
     }
 ```
 
+## Android Build Error Due to AGP Version
+
+If you encounter the following error while building your project:
+```
+Execution failed for task ':app:mergeExtDexDebug'.
+> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
+   > Failed to transform af-android-sdk-6.16.0.aar (com.appsflyer:af-android-sdk:6.16.0) to match attributes {artifactType=android-dex, asm-transformed-variant=NONE, dexing-enable-desugaring=true, dexing-is-debuggable=true, dexing-min-sdk=21, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=aar, org.gradle.status=release, org.gradle.usage=java-runtime}.
+      > Execution failed for DexingWithClasspathTransform: /Users/amit.levy/.gradle/caches/transforms-3/fb46dcab411d99e4e97f01029413cab1/transformed/jetified-af-android-sdk-6.16.0-runtime.jar.
+         > Error while dexing.
+```
+
+This error occurs if you are using Android Gradle Plugin (AGP) below 8.2.0 due to a known bug in R8.
+Google has already resolved this issue
+[see Google Issue Tracker](https://issuetracker.google.com/issues/290412574?pli=1).
+
+
+### Solutions
+
+To fix this issue, you have two options:
+1. Upgrade AGP to 8.2.0+ (Recommended):
+  <br/>Updating AGP to 8.2.0 or later ensures compatibility with the latest R8 version.<br/>Sync and rebuild your project
+
+2. Manually Override the R8 Version
+<br/>If upgrading AGP is not an option, you can manually set an external newer R8 version to override the bundled one.
+<br/> Open android/build.gradle and add this inside the buildscript {} block then sync and rebuild your project:
+```
+buildscript {
+    repositories {
+        mavenCentral()
+        maven {
+            url = uri("https://storage.googleapis.com/r8-releases/raw")
+        }
+    }
+    dependencies {
+        classpath("com.android.tools:r8:8.2.26")
+    }
+}
+```
+
 ## Add strict-mode for App-kids
 Starting from version **6.1.10** iOS SDK comes in two variants: **Strict** mode and **Regular** mode. Please read more [here](https://dev.appsflyer.com/hc/docs/install-ios-sdk#strict-mode-sdk)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
 - Tested with React-Native **v0.62.0** (older versions might be supported)
 
 ## <a id="breaking-changes"> ❗❗ Breaking changes when updating to v6.x.x❗❗
+- Starting from version `6.16.0`, Android minimum SDK version is 21. 
+<br/>Potential Build Issues: If you are using Android Gradle Plugin (AGP) below 8.2.0, you may encounter build errors on Android.
+<br/>To resolve this, refer to the [Android Build Error Due to AGP Version](./Docs/RN_Installation.md#android-build-error-due-to-agp-version).
 
 - From version `6.15.1`, upgraded to targetSDKVersion 34, Java 17, and Gradle 8.7 in [AppsFlyer Android SDK v6.15.1](https://support.appsflyer.com/hc/en-us/articles/115001256006-AppsFlyer-Android-SDK-release-notes).
 

--- a/demos/appsflyer-react-native-app/android/build.gradle
+++ b/demos/appsflyer-react-native-app/android/build.gradle
@@ -11,12 +11,16 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url = uri("https://storage.googleapis.com/r8-releases/raw")
+        }
     }
     dependencies {
         //classpath("com.android.tools.build:gradle:4.2.1")
-        classpath('com.android.tools.build:gradle:8.2.0')
+        classpath('com.android.tools.build:gradle:7.1.3')
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+        classpath("com.android.tools:r8:8.2.26")
     }
 }
 

--- a/demos/appsflyer-react-native-app/android/gradle.properties
+++ b/demos/appsflyer-react-native-app/android/gradle.properties
@@ -26,6 +26,3 @@ android.enableJetifier=true
 
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.93.0
-android.defaults.buildfeatures.buildconfig=true
-android.nonTransitiveRClass=false
-android.nonFinalResIds=false

--- a/demos/appsflyer-react-native-app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/demos/appsflyer-react-native-app/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Sep 01 10:19:20 IDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
In Android v6.16.0 a `sealed` class was added to the SDK and trigger the following error from R8:
> Task :app:mergeExtDexRegularGooglePlayRelease FAILED
ERROR:/Users/paz.lavi/.gradle/caches/transforms-3/edb7d7fc6cedc8dbd3d8228dc36a6289/transformed/jetified-af-android-sdk-6.16.0-runtime.jar: D8: com.android.tools.r8.internal.Jc: Sealed classes are not supported as program classes
This is a bug in R8 that already solved by google (ref: https://issuetracker.google.com/issues/290412574?pli=1).
