### PR TITLE
fix: No enum constant com.appsflyer.MediationNetwork.APPLOVINMAX

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ appsFlyer.logEvent = logEvent;
 
 export const MEDIATION_NETWORK = Object.freeze({
 	IRONSOURCE : "ironsource",
-	APPLOVIN_MAX : "applovinmax",
+	APPLOVIN_MAX : "applovin_max",
 	GOOGLE_ADMOB : "googleadmob",
 	FYBER : "fyber",
 	APPODEAL : "appodeal",


### PR DESCRIPTION
fixes a crash on Android by making consistent `APPLOVIN_MAX` enum.
```
No enum constant com.appsflyer.MediationNetwork.APPLOVINMAX
```

This happened because the java expected `APPLOVIN_MAX`, but js used `toUpperCase(applovinmax)`.