### PR TITLE
Remove typescript from index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function initSdkCallback(options, successC, errorC) {
 	return RNAppsFlyer.initSdkWithCallBack(options, successC, errorC);
 }
 
-function initSdkPromise(options): Promise<string> {
+function initSdkPromise(options) {
 	if (typeof options.appId !== 'string' && typeof options.appId !== 'undefined') {
 		return Promise.reject('appId should be a string!');
 	}
@@ -25,7 +25,7 @@ function initSdkPromise(options): Promise<string> {
 	return RNAppsFlyer.initSdkWithPromise(options);
 }
 
-function initSdk(options, success, error): Promise<string> {
+function initSdk(options, success, error) {
 	if (success && error) {
 		//initSdk is a callback function
 		initSdkCallback(options, success, error);
@@ -41,11 +41,11 @@ function logEventCallback(eventName, eventValues, successC, errorC) {
 	return RNAppsFlyer.logEvent(eventName, eventValues, successC, errorC);
 }
 
-function logEventPromise(eventName, eventValues): Promise<string> {
+function logEventPromise(eventName, eventValues) {
 	return RNAppsFlyer.logEventWithPromise(eventName, eventValues);
 }
 
-function logEvent(eventName, eventValues, success, error): Promise<string> {
+function logEvent(eventName, eventValues, success, error) {
 	if (success && error) {
 		//logEvent is a callback function
 		logEventCallback(eventName, eventValues, success, error);


### PR DESCRIPTION
These type annotations should not be in a .js file. It seems that metro ignored them, but stricter compilers like re-pack.dev will fail:
```
✖ [19:57:56.469Z][LoggerPlugin] Failed to build bundle due to errors
✖ [19:57:56.469Z][LoggerPlugin] Error in "./node_modules/react-native-appsflyer/index.js":
  × Module build failed:
  ├─▶   ×   × Expected '{', got ':'
  │     │     ╭─[node_modules/react-native-appsflyer/index.js:18:1]
  │     │  15 │     return RNAppsFlyer.initSdkWithCallBack(options, successC, errorC);
  │     │  16 │ }
  │     │  17 │
  │     │  18 │ function initSdkPromise(options): Promise<string> {
  │     │     ·                                 ─
  │     │  19 │     if (typeof options.appId !== 'string' && typeof options.appId !== 'undefined') {
  │     │  20 │         return Promise.reject('appId should be a string!');
  │     │  21 │     }
  │     │     ╰────
  │     │
  │
  ╰─▶ Syntax Error
```