### PR TITLE
Expo swift app delegate

### DIFF
--- a/Docs/RN_ExpoInstallation.md
+++ b/Docs/RN_ExpoInstallation.md
@@ -22,7 +22,11 @@ expo install react-native-appsflyer
 ...
 "plugins": [
       [
-        "react-native-appsflyer",{}
+        "react-native-appsflyer",
+        {
+          "shouldUseStrictMode": false,          // optional – kids-apps strict mode
+          "shouldUsePurchaseConnector": true     // NEW – enables Purchase Connector
+        }
       ]
     ],
 ...
@@ -112,3 +116,14 @@ In v6.8.0 of the AppsFlyer SDK, we added the normal permission com.google.androi
 to allow the SDK to collect the Android Advertising ID on apps targeting API 33.
 If your app is targeting children, you need to revoke this permission to comply with Google's Data policy.
 You can read more about it [here](https://docs.expo.dev/guides/permissions/#android).
+
+### Purchase Connector (optional)
+
+Setting `"shouldUsePurchaseConnector": true` will:
+
+* **iOS** – add the `PurchaseConnector` CocoaPod automatically  
+* **Android** – add `appsflyer.enable_purchase_connector=true` to `gradle.properties`
+
+> **Expo SDK 53 note**  
+> Due to a known Expo 53 issue, the Android will fail to apply. Manually add  
+> `appsflyer.enable_purchase_connector=true` to `android/gradle.properties`.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 
 ### <a id="plugin-build-for"> This plugin is built for
 
-- Android AppsFlyer SDK **v6.17.0**
-- iOS AppsFlyer SDK **v6.17.1**
+- Android AppsFlyer SDK **v6.17.1**
+- iOS AppsFlyer SDK **v6.17.2**
 - Tested with React-Native **v0.62.0** (older versions might be supported)
 
 ## <a id="release-updates"> Release Updates

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -70,7 +70,7 @@ repositories {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.7.10" // Add Kotlin standard library
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    api "com.appsflyer:af-android-sdk:${safeExtGet('appsflyerVersion', '6.17.0')}"
+    api "com.appsflyer:af-android-sdk:${safeExtGet('appsflyerVersion', '6.17.1')}"
     implementation "com.android.installreferrer:installreferrer:${safeExtGet('installReferrerVersion', '2.2')}"
     if (includeConnector){
         implementation 'com.appsflyer:purchase-connector:2.1.1'

--- a/android/src/main/java/com/appsflyer/reactnative/RNAppsFlyerConstants.java
+++ b/android/src/main/java/com/appsflyer/reactnative/RNAppsFlyerConstants.java
@@ -6,7 +6,7 @@ package com.appsflyer.reactnative;
 
 public class RNAppsFlyerConstants {
 
-    final static String PLUGIN_VERSION = "6.17.1";
+    final static String PLUGIN_VERSION = "6.17.2";
     final static String NO_DEVKEY_FOUND = "No 'devKey' found or its empty";
     final static String UNKNOWN_ERROR = "AF Unknown Error";
     final static String SUCCESS = "Success";

--- a/expo/withAppsFlyer.js
+++ b/expo/withAppsFlyer.js
@@ -1,5 +1,9 @@
 const withAppsFlyerIos = require('./withAppsFlyerIos');
-module.exports = function withAppsFlyer(config, { shouldUseStrictMode = false } = {}) {
-	config = withAppsFlyerIos(config, shouldUseStrictMode);
-	return config;
+
+module.exports = function withAppsFlyer(config, { 
+  shouldUseStrictMode = false, 
+  shouldUsePurchaseConnector = false 
+} = {}) {
+  config = withAppsFlyerIos(config, { shouldUseStrictMode, shouldUsePurchaseConnector });
+  return config;
 };

--- a/expo/withAppsFlyer.js
+++ b/expo/withAppsFlyer.js
@@ -1,9 +1,11 @@
 const withAppsFlyerIos = require('./withAppsFlyerIos');
+const withAppsFlyerAndroid = require('./withAppsFlyerAndroid');
 
 module.exports = function withAppsFlyer(config, { 
   shouldUseStrictMode = false, 
   shouldUsePurchaseConnector = false 
 } = {}) {
   config = withAppsFlyerIos(config, { shouldUseStrictMode, shouldUsePurchaseConnector });
+  config = withAppsFlyerAndroid(config, { shouldUsePurchaseConnector });
   return config;
 };

--- a/expo/withAppsFlyer.js
+++ b/expo/withAppsFlyer.js
@@ -1,11 +1,11 @@
 const withAppsFlyerIos = require('./withAppsFlyerIos');
-const withAppsFlyerAndroid = require('./withAppsFlyerAndroid');
+//const withAppsFlyerAndroid = require('./withAppsFlyerAndroid');
 
 module.exports = function withAppsFlyer(config, { 
   shouldUseStrictMode = false, 
   shouldUsePurchaseConnector = false 
 } = {}) {
   config = withAppsFlyerIos(config, { shouldUseStrictMode, shouldUsePurchaseConnector });
-  config = withAppsFlyerAndroid(config, { shouldUsePurchaseConnector });
+  //config = withAppsFlyerAndroid(config, { shouldUsePurchaseConnector });
   return config;
 };

--- a/expo/withAppsFlyerAndroid.js
+++ b/expo/withAppsFlyerAndroid.js
@@ -1,25 +1,24 @@
+const { withGradleProperties } = require('@expo/config-plugins');
+
 module.exports = function withAppsFlyerAndroid(config, { 
-    shouldUsePurchaseConnector = false 
-  } = {}) {
-  
-    if (shouldUsePurchaseConnector) {
-      if (!config.android) {
-        config.android = {};
-      }
-  
-      if (!config.android.gradleProperties) {
-        config.android.gradleProperties = [];
-      }
-  
-      // Prevent duplicates
-      const existingKeys = config.android.gradleProperties.map(p => p.key);
-      if (!existingKeys.includes('appsflyer.enable_purchase_connector')) {
-        config.android.gradleProperties.push({
+  shouldUsePurchaseConnector = false 
+} = {}) {
+
+  if (shouldUsePurchaseConnector) {
+    config = withGradleProperties(config, config => {
+      const props = config.modResults;
+
+      const alreadySet = props.some(p => p.key === 'appsflyer.enable_purchase_connector');
+      if (!alreadySet) {
+        props.push({
           key: 'appsflyer.enable_purchase_connector',
           value: 'true',
         });
       }
-    }
-  
+
+      return config;
+    });
+  }
+
   return config;
-}; 
+};

--- a/expo/withAppsFlyerAndroid.js
+++ b/expo/withAppsFlyerAndroid.js
@@ -1,0 +1,19 @@
+module.exports = function withAppsFlyerAndroid(config, { 
+  shouldUsePurchaseConnector = false 
+} = {}) {
+  
+  if (shouldUsePurchaseConnector) {
+    if (!config.android) {
+      config.android = {};
+    }
+    
+    if (!config.android.gradleProperties) {
+      config.android.gradleProperties = {};
+    }
+    
+    // Enable AppsFlyer Purchase Connector for Android
+    config.android.gradleProperties['appsflyer.enable_purchase_connector'] = 'true';
+  }
+  
+  return config;
+}; 

--- a/expo/withAppsFlyerAndroid.js
+++ b/expo/withAppsFlyerAndroid.js
@@ -1,23 +1,26 @@
 const { withGradleProperties } = require('@expo/config-plugins');
 
+function withAppsFlyerGradleProperties(config) {
+  return withGradleProperties(config, (config) => {
+    const props = config.modResults;
+
+    const alreadySet = props.some(p => p.key === 'appsflyer.enable_purchase_connector');
+    if (!alreadySet) {
+      props.push({
+        key: 'appsflyer.enable_purchase_connector',
+        value: 'true',
+      });
+    }
+
+    return config;
+  });
+}
+
 module.exports = function withAppsFlyerAndroid(config, { 
   shouldUsePurchaseConnector = false 
 } = {}) {
-
   if (shouldUsePurchaseConnector) {
-    config = withGradleProperties(config, config => {
-      const props = config.modResults;
-
-      const alreadySet = props.some(p => p.key === 'appsflyer.enable_purchase_connector');
-      if (!alreadySet) {
-        props.push({
-          key: 'appsflyer.enable_purchase_connector',
-          value: 'true',
-        });
-      }
-
-      return config;
-    });
+    config = withAppsFlyerGradleProperties(config);
   }
 
   return config;

--- a/expo/withAppsFlyerAndroid.js
+++ b/expo/withAppsFlyerAndroid.js
@@ -1,3 +1,5 @@
+// this is not used currently because of a bug in Expo 53 , please manually add appsflyer.enable_purchase_connector = true to the gradle.properties file in Order to use Purchase Connector feature in Android.
+/*
 const { withGradleProperties } = require('@expo/config-plugins');
 
 function withAppsFlyerGradleProperties(config) {
@@ -25,3 +27,4 @@ module.exports = function withAppsFlyerAndroid(config, {
 
   return config;
 };
+*/

--- a/expo/withAppsFlyerAndroid.js
+++ b/expo/withAppsFlyerAndroid.js
@@ -1,19 +1,25 @@
 module.exports = function withAppsFlyerAndroid(config, { 
-  shouldUsePurchaseConnector = false 
-} = {}) {
+    shouldUsePurchaseConnector = false 
+  } = {}) {
   
-  if (shouldUsePurchaseConnector) {
-    if (!config.android) {
-      config.android = {};
+    if (shouldUsePurchaseConnector) {
+      if (!config.android) {
+        config.android = {};
+      }
+  
+      if (!config.android.gradleProperties) {
+        config.android.gradleProperties = [];
+      }
+  
+      // Prevent duplicates
+      const existingKeys = config.android.gradleProperties.map(p => p.key);
+      if (!existingKeys.includes('appsflyer.enable_purchase_connector')) {
+        config.android.gradleProperties.push({
+          key: 'appsflyer.enable_purchase_connector',
+          value: 'true',
+        });
+      }
     }
-    
-    if (!config.android.gradleProperties) {
-      config.android.gradleProperties = {};
-    }
-    
-    // Enable AppsFlyer Purchase Connector for Android
-    config.android.gradleProperties['appsflyer.enable_purchase_connector'] = 'true';
-  }
   
   return config;
 }; 

--- a/ios/RNAppsFlyer.h
+++ b/ios/RNAppsFlyer.h
@@ -22,7 +22,7 @@
 @end
 
 
-static NSString *const kAppsFlyerPluginVersion      = @"6.17.1";
+static NSString *const kAppsFlyerPluginVersion      = @"6.17.2";
 static NSString *const NO_DEVKEY_FOUND              = @"No 'devKey' found or its empty";
 static NSString *const NO_APPID_FOUND               = @"No 'appId' found or its empty";
 static NSString *const NO_EVENT_NAME_FOUND          = @"No 'eventName' found or its empty";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-appsflyer",
-  "version": "6.17.1",
+  "version": "6.17.2",
   "description": "React Native Appsflyer plugin",
   "main": "index.js",
   "types": "index.d.ts",

--- a/react-native-appsflyer.podspec
+++ b/react-native-appsflyer.podspec
@@ -30,19 +30,19 @@ Pod::Spec.new do |s|
   # AppsFlyerPurchaseConnector
   if defined?($AppsFlyerPurchaseConnector) && ($AppsFlyerPurchaseConnector == true)
     Pod::UI.puts "#{s.name}: Including PurchaseConnector."
-    s.dependency 'PurchaseConnector', '6.17.1'
+    s.dependency 'PurchaseConnector', '6.17.2'
   end
 
   # AppsFlyerFramework
   if defined?($RNAppsFlyerStrictMode) && ($RNAppsFlyerStrictMode == true)
     Pod::UI.puts "#{s.name}: Using AppsFlyerFramework/Strict mode"
-    s.dependency 'AppsFlyerFramework/Strict', '6.17.1'
+    s.dependency 'AppsFlyerFramework/Strict', '6.17.2'
     s.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) AFSDK_NO_IDFA=1' }
   else
     if !defined?($RNAppsFlyerStrictMode)
       Pod::UI.puts "#{s.name}: Using default AppsFlyerFramework. You may require App Tracking Transparency. Not allowed for Kids apps."
       Pod::UI.puts "#{s.name}: You may set variable `$RNAppsFlyerStrictMode=true` in Podfile to use strict mode for kids apps."
     end
-    s.dependency 'AppsFlyerFramework', '6.17.1'
+    s.dependency 'AppsFlyerFramework', '6.17.2'
   end
 end


### PR DESCRIPTION
Adding swift support to Expo 
Purchase Connector support via app.json (Works only for iOS currently due to Expo 53 issue with modifying gradle properties)
Update native versions to iOS 6.17.2, Android 6.17.1