### PR TITLE
Update import path for react_native_appsflyer

### DIFF
--- a/ios/PCAppsFlyer.m
+++ b/ios/PCAppsFlyer.m
@@ -7,7 +7,7 @@ static NSString *const TAG = @"[AppsFlyer_PurchaseConnector] ";
 
 #if __has_include(<PurchaseConnector/PurchaseConnector.h>)
 #import <PurchaseConnector/PurchaseConnector.h>
-#import <react_native_appsflyer-Swift.h>
+#import <react_native_appsflyer/react_native_appsflyer-Swift.h>
 
 @implementation PCAppsFlyer
 @synthesize bridge = _bridge;


### PR DESCRIPTION
fix the error : Pods/react-native-appsflyer: 'react_native_appsflyer-Swift.h' file not found

related https://github.com/AppsFlyerSDK/appsflyer-react-native-plugin/issues/646