### PR TITLE
Remove log spam from Purchase Connector being disabled

### DIFF
--- a/expo/withAppsFlyerAndroid.js
+++ b/expo/withAppsFlyerAndroid.js
@@ -51,8 +51,6 @@ function withCustomAndroidManifest(config) {
 module.exports = function withAppsFlyerAndroid(config, { shouldUsePurchaseConnector = false } = {}) {
   if (shouldUsePurchaseConnector) {
     config = addPurchaseConnectorFlag(config);
-  } else {
-    console.log('[AppsFlyerPlugin] Purchase Connector disabled, skipping gradle property injection');
   }
   
   // Always apply Android manifest modifications for secure data handling


### PR DESCRIPTION
When not using the Purchase Connector, this message was getting logged all the time during development with Expo. Every hot reload would result in this being logged, even when not working on Android.