### PR TITLE
fix linting errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -415,14 +415,3 @@ declare module "react-native-appsflyer" {
 
   export default appsFlyer;
 }
-
-// Explicit ambient declarations for ESLint compatibility
-// ESLint's import resolver doesn't recognize exports inside 'declare module' blocks.
-// These top-level declarations allow ESLint to detect the exports.
-declare const StoreKitVersion: { readonly SK1: "SK1"; readonly SK2: "SK2" };
-declare const AppsFlyerPurchaseConnector: any; // Type is defined in declare module above
-declare const AppsFlyerPurchaseConnectorConfig: any; // Type is defined in declare module above  
-declare const appsFlyer: any; // Type is defined in declare module above
-
-export { StoreKitVersion, AppsFlyerPurchaseConnector, AppsFlyerPurchaseConnectorConfig };
-export { appsFlyer as default };


### PR DESCRIPTION
# Problem
Linting was working in 6.17.1, but broken by 6.17.8

<img width="1466" height="730" alt="Screenshot 11" src="https://github.com/user-attachments/assets/88455938-2a9a-4ac7-96d0-0d55c1c0412f" />

# Solution

The declare module block is sufficient; the duplicate ambient declarations were unnecessary and caused the issue.
**What was happening:**
- The` declare module "react-native-appsflyer"` block (lines 12-417) defines all the types correctly
- The ambient declarations at the bottom were duplicates that originally used `any` types, causing the linting errors
- TypeScript and ESLint work fine with just the declare module block

**Why the original code had both:**
The comment mentioned "ESLint's import resolver doesn't recognize exports inside 'declare module' blocks," but modern ESLint with TypeScript support handles this correctly. The ambient declarations were redundant and introduced the `any` type problem.