### PR TITLE
fix(expo): clean stale tools:replace entries when removing backup attributes

### DIFF
--- a/expo/withAppsFlyerAndroid.js
+++ b/expo/withAppsFlyerAndroid.js
@@ -73,16 +73,20 @@ function withCustomAndroidManifest(config, { preferAppsFlyerBackupRules = false 
       // to tools:replace; leaving them after the attributes are deleted causes a manifest merge
       // failure: "Multiple entries with same key: <attr>=REPLACE".
       if (appAttrs['tools:replace']) {
-        const filtered = appAttrs['tools:replace']
+        const existingReplaceEntries = appAttrs['tools:replace']
           .split(',')
           .map((s) => s.trim())
-          .filter((s) => s && !removedKeys.includes(s));
-        if (filtered.length > 0) {
-          appAttrs['tools:replace'] = filtered.join(', ');
-        } else {
-          delete appAttrs['tools:replace'];
+          .filter(Boolean);
+        const filtered = existingReplaceEntries.filter((s) => !removedKeys.includes(s));
+
+        if (filtered.length !== existingReplaceEntries.length) {
+          if (filtered.length > 0) {
+            appAttrs['tools:replace'] = filtered.join(', ');
+          } else {
+            delete appAttrs['tools:replace'];
+          }
+          console.log('[AppsFlyerPlugin] Cleaned stale tools:replace entries for removed backup attributes');
         }
-        console.log('[AppsFlyerPlugin] Cleaned stale tools:replace entries for removed backup attributes');
       }
     }
 

--- a/expo/withAppsFlyerAndroid.js
+++ b/expo/withAppsFlyerAndroid.js
@@ -52,16 +52,37 @@ function withCustomAndroidManifest(config, { preferAppsFlyerBackupRules = false 
 
     // preferAppsFlyerBackupRules === true
     if (hasDataExtractionRules || hasFullBackupContent) {
-      // Remove conflicting attributes from app's manifest
+      // Remove conflicting attributes from app's manifest.
       // This allows AppsFlyer SDK's built-in backup rules to be used instead.
+      const removedKeys = [];
+
       if (hasDataExtractionRules) {
         delete appAttrs['android:dataExtractionRules'];
+        removedKeys.push('android:dataExtractionRules');
         console.log('[AppsFlyerPlugin] Removed android:dataExtractionRules to use AppsFlyer SDK rules');
       }
 
       if (hasFullBackupContent) {
         delete appAttrs['android:fullBackupContent'];
+        removedKeys.push('android:fullBackupContent');
         console.log('[AppsFlyerPlugin] Removed android:fullBackupContent to use AppsFlyer SDK rules');
+      }
+
+      // Clean removed attribute names from any existing tools:replace to avoid stale replace
+      // directives. Other plugins (e.g. expo-secure-store) may have already added these keys
+      // to tools:replace; leaving them after the attributes are deleted causes a manifest merge
+      // failure: "Multiple entries with same key: <attr>=REPLACE".
+      if (appAttrs['tools:replace']) {
+        const filtered = appAttrs['tools:replace']
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s) => s && !removedKeys.includes(s));
+        if (filtered.length > 0) {
+          appAttrs['tools:replace'] = filtered.join(', ');
+        } else {
+          delete appAttrs['tools:replace'];
+        }
+        console.log('[AppsFlyerPlugin] Cleaned stale tools:replace entries for removed backup attributes');
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes a manifest merge failure that occurs when `preferAppsFlyerBackupRules=true` and another Expo plugin (e.g. `expo-secure-store`) has already added the removed backup attribute names to `tools:replace`.

When the plugin deletes `android:dataExtractionRules` or `android:fullBackupContent` from the app's manifest, any existing `tools:replace` entry referencing those same attribute names becomes stale. The Android manifest merger then fails with:

```
Multiple entries with same key: android:dataExtractionRules=REPLACE
```

**Changes:**
- Track which backup attributes were deleted (`removedKeys`).
- After deletion, filter stale attribute names out of any existing `tools:replace` value; delete `tools:replace` entirely if it becomes empty.
- Only mutate the attribute and emit the log when entries were actually removed (no-ops cleanly when `tools:replace` contains no stale entries).

## Test plan
- [ ] `preferAppsFlyerBackupRules=false` (default): no manifest changes, no log output
- [ ] `preferAppsFlyerBackupRules=true`, app has no backup attributes: no manifest changes
- [ ] `preferAppsFlyerBackupRules=true`, app has backup attributes but no `tools:replace`: attributes removed, no `tools:replace` clean-up log
- [ ] `preferAppsFlyerBackupRules=true`, app has backup attributes + `tools:replace` containing those keys: attributes removed, stale keys filtered from `tools:replace`, log emitted
- [ ] `preferAppsFlyerBackupRules=true`, `tools:replace` contains only stale keys: entire `tools:replace` attribute deleted