### PR TITLE
Upgrade `actions/setup-node` to v6

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -70,7 +70,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -165,10 +165,9 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Publish to npm
         if: needs.validate-release.outputs.is_dry_run != 'true'
@@ -314,7 +313,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 

--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -191,7 +191,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -463,10 +463,9 @@ jobs:
           ref: ${{ needs.prepare-branch.outputs.release_branch }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
The `registry-url` parameter is no longer required as `actions/setup-node@v6` defaults to the public npm registry. This simplifies the workflow configurations.