### PR TITLE
chore: Bump js-core-plugin and standardize unregisterDeepLinkListener name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 7.0.2
- Release date: *TBD*
+ Release date: *2026-08-26*
 
 Upgrading from 6.18.0? See [MIGRATION.md](MIGRATION.md) for the full before/after guide.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ See [MIGRATION.md](MIGRATION.md) for full before/after examples for each item be
 
 - **Every method takes one params object** — e.g. `init(devKey, appId)` → `init({devKey, appId})`.
 - **`initSdk(options)` removed** — replaced by `init({devKey, appId})` + explicit `start()`. `isDebug`/`onInstallConversionDataListener`/`onDeepLinkListener`/`manualStart` options removed; use `enableDebug()`, `registerConversionListener()`/`registerDeepLinkListener()`, and `start()` instead. `timeToWaitForATTUserAuthorization` has no replacement — request ATT yourself before `init()`.
-- **`onInstallConversionData`/`onInstallConversionFailure`/`onDeepLink` removed** — use `registerConversionListener()`/`registerDeepLinkListener()` + `unregisterConversionListener()`/`unregisterDeeplinkListener()`.
+- **`onInstallConversionData`/`onInstallConversionFailure`/`onDeepLink` removed** — use `registerConversionListener()`/`registerDeepLinkListener()` + `unregisterConversionListener()`/`unregisterDeepLinkListener()`.
 - **`onAppOpenAttribution`/`onAttributionFailure`/`performOnAppAttribution` removed** — merged into `registerDeepLinkListener`.
 - **`validateAndLogInAppPurchase(purchaseInfo, successC, errorC)` removed** — new signature is `validateAndLogInAppPurchase({purchase, additionalParameters?})`, no callback argument. `AFPurchaseDetails` split into `AFPurchaseDetailsAndroid`/`AFPurchaseDetailsIOS`.
 - **`generateInviteLink`'s `deeplinkPath` removed** — was already a no-op. Every other field now nests under a `parameters` object.

--- a/Docs/RN_API.md
+++ b/Docs/RN_API.md
@@ -104,7 +104,7 @@ The list of available methods for this plugin is described below.
   - [unregisterConversionListener](#unregisterconversionlistener)
   - [onAppOpenAttribution / onAttributionFailure — removed in 7.0.0](#onappopenattribution--onattributionfailure--removed-in-700)
   - [registerDeepLinkListener](#registerdeeplinklistener)
-  - [unregisterDeeplinkListener](#unregisterdeeplinklistener)
+  - [unregisterDeepLinkListener](#unregisterdeeplinklistener)
   - [registerSessionReadyListener](#registersessionreadylistener)
   - [isSessionReady](#issessionready)
   - [unregisterSessionReadyListener](#unregistersessionreadylistener)
@@ -1880,12 +1880,12 @@ AppsFlyer.init(/*...*/);
 
 The callback receives a `{status, deepLink?, error?}` object (`status` is `'FOUND' | 'NOT_FOUND' | 'ERROR'`) — see `DeepLinkData`.
 
-To stop the underlying native listener, call `unregisterDeeplinkListener()` (Android only — see below).
+To stop the underlying native listener, call `unregisterDeepLinkListener()` (Android only — see below).
 
 ---
 
-### unregisterDeeplinkListener
-`unregisterDeeplinkListener() : Promise<void>`
+### unregisterDeepLinkListener
+`unregisterDeepLinkListener() : Promise<void>`
 
 Stop the native deep-link listener and clear all registered callbacks. Android only. Takes no arguments.
 
@@ -1893,7 +1893,7 @@ Stop the native deep-link listener and clear all registered callbacks. Android o
 
 ```javascript
 if (Platform.OS == 'android') {
-  AppsFlyer.unregisterDeeplinkListener();
+  AppsFlyer.unregisterDeepLinkListener();
 }
 ```
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -173,7 +173,7 @@ AppsFlyer.registerDeepLinkListener({ onDeepLinking: onDeepLink });
 
 // full teardown (e.g. componentWillUnmount) — Android only, both reject on iOS:
 AppsFlyer.unregisterConversionListener();
-AppsFlyer.unregisterDeeplinkListener();
+AppsFlyer.unregisterDeepLinkListener();
 ```
 
 `onFailure` now receives the failure message as a plain `string`, not a `ConversionData`-shaped

--- a/__tests__/rpc-wire-contract.test.js
+++ b/__tests__/rpc-wire-contract.test.js
@@ -215,9 +215,9 @@ const CALL_SITES = [
 	{ api: 'setCollectAndroidID', platforms: [ANDROID], invoke: (AppsFlyer) => AppsFlyer.setCollectAndroidID({ isCollect: true }) },
 	{ api: 'setDisableNetworkData', platforms: [ANDROID], invoke: (AppsFlyer) => AppsFlyer.setDisableNetworkData({ isDisable: true }) },
 	{
-		api: 'unregisterDeeplinkListener',
+		api: 'unregisterDeepLinkListener',
 		platforms: [ANDROID],
-		invoke: (AppsFlyer) => AppsFlyer.unregisterDeeplinkListener(),
+		invoke: (AppsFlyer) => AppsFlyer.unregisterDeepLinkListener(),
 	},
 	{ api: 'disableAppSetId', platforms: [ANDROID], invoke: (AppsFlyer) => AppsFlyer.disableAppSetId() },
 	{ api: 'getHostName', platforms: [ANDROID], invoke: (AppsFlyer) => AppsFlyer.getHostName() },

--- a/demos/appsflyer-expo-app/rpcCatalog.js
+++ b/demos/appsflyer-expo-app/rpcCatalog.js
@@ -102,7 +102,7 @@ export const RPC_CATALOG = [
 	{ name: 'start', group: 'Start', platform: 'both', run: () => AppsFlyer.start() },
 	{ name: 'unregisterSessionReadyListener', group: 'Listener', platform: 'both', run: () => AppsFlyer.unregisterSessionReadyListener() },
 	{ name: 'unregisterConversionListener', group: 'Listener', platform: 'android', run: () => AppsFlyer.unregisterConversionListener() },
-	{ name: 'unregisterDeeplinkListener', group: 'Listener', platform: 'android', run: () => AppsFlyer.unregisterDeeplinkListener() },
+	{ name: 'unregisterDeepLinkListener', group: 'Listener', platform: 'android', run: () => AppsFlyer.unregisterDeepLinkListener() },
 
 	{ name: 'logEvent', group: 'Event', platform: 'both', run: () => AppsFlyer.logEvent({ eventName: 'test_event', eventValues: { key: 'value' }, awaitResponse: true }) },
 

--- a/demos/appsflyer-react-native-app/components/AppsFlyer.js
+++ b/demos/appsflyer-react-native-app/components/AppsFlyer.js
@@ -48,7 +48,7 @@ export function AFInit(onConversionData, onDeepLink) {
 
 export function AFCleanup() {
   //AppsFlyer.unregisterConversionListener();
-  //AppsFlyer.unregisterDeeplinkListener();
+  //AppsFlyer.unregisterDeepLinkListener();
 }
 
 // Sends in-app events to AppsFlyer servers. name is the events name ('simple event') and the values are a JSON ({info: 'fff', size: 5})

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-native": ">=0.76.0"
   },
   "dependencies": {
-    "@appsflyer-sdk/js-core-plugin": "7.0.14"
+    "@appsflyer-sdk/js-core-plugin": "7.0.15"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.26.9",


### PR DESCRIPTION
Updates `@appsflyer-sdk/js-core-plugin` to `7.0.15`. This change standardizes the `unregisterDeeplinkListener` method name to `unregisterDeepLinkListener` across documentation, tests, and demo applications to align with the updated plugin API.