### PR TITLE
fix(e2e): stop stdin drain in scenario-runner pre-actions

### DIFF
--- a/scripts/af-scenario-runner.sh
+++ b/scripts/af-scenario-runner.sh
@@ -547,7 +547,10 @@ run_phase_command() {
 
   log_info "${label}: ${command}"
   set +e
-  output=$(eval "$command" 2>&1)
+  # </dev/null: this runs inside the pre_actions `while read ... done < <(...)` loop, and a
+  # stdin-reading command here (e.g. `adb shell`) would inherit that loop's fd0 and drain it,
+  # silently starving `read` of the remaining pre_action lines (e.g. the following `sleep`).
+  output=$(eval "$command" 2>&1 </dev/null)
   status=$?
   set -e
 


### PR DESCRIPTION
## Bug
`run_phase_command`'s `eval "$command" 2>&1` had no stdin redirection. Called from the `pre_actions` `while IFS= read -r action; do ... done < <(jq -c ...)` loop, a stdin-reading pre-action (e.g. `adb shell am start ...`) inherits the loop's fd0 and drains it — the loop's `read` hits EOF before reaching the next pre_action line (e.g. the `sleep 1` after backgrounding), so that step silently never runs or logs.

## Fix
Scoped `</dev/null` redirect on that one eval call, with a comment explaining why.

## Verification
- `bash -n scripts/af-scenario-runner.sh` — syntax OK
- Minimal repro harness confirmed the drain with an unfixed eval and confirmed both loop steps run with `</dev/null` added
